### PR TITLE
Added new middleware to get full http response

### DIFF
--- a/lib/chef-analytics/http/full_response.rb
+++ b/lib/chef-analytics/http/full_response.rb
@@ -1,0 +1,47 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ChefAnalytics
+  class HTTP
+    class FullResponse
+      attr_accessor :last_response
+
+      def initialize(opts={})
+      end
+
+      def handle_request(method, url, headers={}, data=false)
+        [method, url, headers, data]
+      end
+
+      def handle_response(http_response, rest_request, return_value)
+        # Duplicate the full response and the response body so we have access to
+        # headers and the response code. This feels like a hack but it is the
+        # only way to work around:
+        # https://github.com/chef/chef/blob/master/lib/chef/http.rb#L147
+        [http_response, rest_request, http_response]
+      end
+
+      def stream_response_handler(response)
+        nil
+      end
+
+      def handle_stream_complete(http_response, rest_request, return_value)
+        [http_response, rest_request, http_response]
+      end
+    end
+  end
+end

--- a/lib/chef-analytics/server_api.rb
+++ b/lib/chef-analytics/server_api.rb
@@ -19,6 +19,7 @@ require 'chef/http'
 require 'chef/http/remote_request_id'
 require 'chef/http/json_output'
 require 'chef-analytics/http/token_authenticator'
+require 'chef-analytics/http/full_response'
 
 module ChefAnalytics
   class ServerAPI < Chef::HTTP
@@ -32,6 +33,7 @@ module ChefAnalytics
       @authenticator = ChefAnalytics::HTTP::TokenAuthenticator.new(options)
       @request_id = Chef::HTTP::RemoteRequestID.new(options)
 
+      @middlewares << ChefAnalytics::HTTP::FullResponse.new(options)
       @middlewares << Chef::HTTP::JSONOutput.new(options)
       @middlewares << @authenticator
       @middlewares << @request_id


### PR DESCRIPTION
By default Chef::HTTP only returns the response body. To make full use of the
analytics api we need access to the status codes and teh headers. This middleware
duplicates the full response body and puts it in place of the response body field.
